### PR TITLE
fixed typo at COMPO vardef

### DIFF
--- a/insstall_docker_nproxyman.sh
+++ b/insstall_docker_nproxyman.sh
@@ -12,7 +12,7 @@ installApps()
     
     ISACT=`sudo systemctl is-active docker`
     ISCOMP=`docker-compose -v`
-    COMPNO = "command not found"
+    COMPNO="command not found"
 
     #### Try to check whether docker is installed and running - don't prompt if it is
     if [[ "$ISACT" != "active" ]]; then


### PR DESCRIPTION
fixes error ./insstall_docker_nproxyman.sh: line 15: COMPNO: command not found when executing